### PR TITLE
fix: remove unsupported next.js experimental options

### DIFF
--- a/app/(dashboard)/pricing/page.tsx
+++ b/app/(dashboard)/pricing/page.tsx
@@ -4,8 +4,8 @@ import { Check } from 'lucide-react';
 import { getStripePrices, getStripeProducts } from '@/lib/payments/stripe';
 import { SubmitButton } from './submit-button';
 
-// Prices are fresh for one hour max
-export const revalidate = 3600;
+// Fetch pricing data at request time to avoid build-time API calls
+export const dynamic = 'force-dynamic';
 
 interface ProductWithPrice {
   id: string;

--- a/app/globals.css
+++ b/app/globals.css
@@ -77,7 +77,7 @@
 
 @layer utilities {
   body {
-    font-family: "Manrope", Arial, Helvetica, sans-serif;
+    font-family: Arial, Helvetica, sans-serif;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import './globals.css';
 import type { Metadata, Viewport } from 'next';
-import { Manrope } from 'next/font/google';
 import { getUser, getTeamForUser } from '@/lib/db/queries';
 import { SWRConfig } from 'swr';
 
@@ -13,7 +12,6 @@ export const viewport: Viewport = {
   maximumScale: 1
 };
 
-const manrope = Manrope({ subsets: ['latin'] });
 
 export default function RootLayout({
   children
@@ -23,7 +21,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`bg-white dark:bg-gray-950 text-black dark:text-white ${manrope.className}`}
+      className="bg-white dark:bg-gray-950 text-black dark:text-white"
     >
       <body className="min-h-[100dvh] bg-gray-50">
         <SWRConfig

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -5,11 +5,6 @@ import { NewUser } from '@/lib/db/schema';
 
 const key = new TextEncoder().encode(process.env.AUTH_SECRET);
 const SALT_ROUNDS = 10;
-export interface SessionData {
-  user: { id: string };
-  expires: string;
-  stripeRole?: "free" | "paid";    // ← 新增
-}
 export async function hashPassword(password: string) {
   return hash(password, SALT_ROUNDS);
 }
@@ -21,9 +16,10 @@ export async function comparePasswords(
   return compare(plainTextPassword, hashedPassword);
 }
 
-type SessionData = {
+export type SessionData = {
   user: { id: number };
   expires: string;
+  stripeRole?: "free" | "paid";
 };
 
 export async function signToken(payload: SessionData) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,9 +2,7 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   experimental: {
-    ppr: true,
-    clientSegmentCache: true,
-    nodeMiddleware: true
+    clientSegmentCache: true
   }
 };
 


### PR DESCRIPTION
## Summary
- remove unsupported `ppr` and `nodeMiddleware` options from `next.config.ts`
- drop remote Manrope font and rely on system fonts
- fetch pricing data dynamically to avoid build-time API calls

## Testing
- `POSTGRES_URL=postgres://localhost STRIPE_SECRET_KEY=dummy STRIPE_WEBHOOK_SECRET=dummy npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aab911cd148326a5652226780641a3